### PR TITLE
TECH-1124 - Upgrading Node.js 12 (End-of-Life) Github Actions to Node.js 16

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
 
@@ -27,7 +27,7 @@ jobs:
 
       - id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ matrix.os }}-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
TECH-1124 - Node.js 12 Github Actions are deprecated as Node.js 12 reached End-of-Life on April 2022. This PR upgrades them to Node.js 16